### PR TITLE
Bugfix for DLCs shown in the pinned giveaways that you've already won

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ class Page:
         filtered_url = sg.filters[filter_type] % page
         paginated_url = f"{sg.base}/giveaways/{filtered_url}"
         soup = sg.get_soup_from_page(paginated_url)
+        soup.find("div", class_="pinned-giveaways__outer-wrap").decompose()
         self.games = [
             Game(sg, tag)
             for tag in soup.find_all(self._select_not_entered_game)


### PR DESCRIPTION
If there were DLCs displayed in the pinned giveaways that you already won, the bot would infinitely check the next page for more giveaways and never progress to the next filter.

Fix for #4